### PR TITLE
Added 12 other columns that I have seen NPS send to SQL.

### DIFF
--- a/nps_accounting_alter_table.sql
+++ b/nps_accounting_alter_table.sql
@@ -73,6 +73,18 @@ CREATE TABLE [dbo].[accounting_data_tmp](
 	[MS_Quarantine_State] [int] NULL,
 	[MS_RAS_Correlation_ID] [nvarchar](255) NULL,
 	[MS_Network_Access_Server_Type] [nvarchar](255) NULL,
+	[NAS_Port_Id] [nvarchar](24) NULL,
+	[Framed_MTU] [int] NULL,
+	[Vendor_Specific] [nvarchar](max) NULL,
+	[Event_Source] [nvarchar](max) NULL,
+	[MS_Link_Drop_Time_Limit] [int] NULL,
+	[MS_Link_Utilization_Threshold] [int] NULL,
+	[MS_RAS_RoutingDomain_ID] [nvarchar](38) NULL,
+	[PEAP_Fast_Roamed_Session] [int] NULL,
+	[SAM_Account_Name] [nvarchar](max) NULL,
+	[Acct_Input_Gigawords] [bigint] NULL,
+	[Acct_Output_Gigawords] [bigint] NULL,
+	[Filter_Id] [nvarchar](63) NULL
 	CONSTRAINT [PK_accounting_data_tmp] PRIMARY KEY CLUSTERED 
 	(
         [id] ASC


### PR DESCRIPTION
I am making a large guess as to how your alter table is meant to be used. I am unsure if I have modified the correction portion. I've added twelve other columns. Each of these I have found from monitoring my existing NPS and SQL environments. As I've added each of these slowly over the last 3-4 years I unsure exactly what generated data to be passed within these fields.

Vendor_Specific
Seen in both Access-Request and Access-Accept messages. https://www.rfc-editor.org/rfc/rfc2865#section-5.26

Event_Source
Fairly useless, as I only ever seen the value of "IAS"

My recent records are only show a value of "0" for the following:
MS_Link_Drop_Time_Limit
MS_Link_Utilization_Threshold
PEAP_Fast_Roamed_Session
(not sure if I'm converting Gigawords data correctly)
Acct_Input_Gigawords
Acct_Output_Gigawords

MS_RAS_RoutingDomain_ID
Unsure what this value is. Examples: 91197071, 91196229

SAM_Account_Name
Seen in both Access-Request and Access-Accept messages. 
Example values: domain\ComptuerName$, domain\username, domain\MAC

Filter_Id
Can be returned as part of the Standard RADIUS Attributes (string or hex value)
